### PR TITLE
Add mobile quick actions nav to bottom dock

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,49 +144,6 @@
         </aside>
       </main>
 
-      <section
-        class="mobile-quick-actions"
-        id="mobile-quick-actions"
-        aria-label="Acciones rápidas móviles"
-        data-quick-actions
-      >
-        <h2 class="mobile-quick-actions__title">Acciones rápidas</h2>
-        <div class="mobile-quick-actions__grid">
-          <button
-            class="mobile-quick-actions__button"
-            data-action="feed"
-            data-action-button
-            type="button"
-          >
-            🍎 Dar de comer
-          </button>
-          <button
-            class="mobile-quick-actions__button"
-            data-action="play"
-            data-action-button
-            type="button"
-          >
-            🎲 Jugar
-          </button>
-          <button
-            class="mobile-quick-actions__button"
-            data-action="sleep"
-            data-action-button
-            type="button"
-          >
-            🌙 Dormir
-          </button>
-          <button
-            class="mobile-quick-actions__button"
-            data-action="train"
-            data-action-button
-            type="button"
-          >
-            🏋️ Entrenar
-          </button>
-        </div>
-      </section>
-
       <div
         class="mobile-sheet-toggles"
         role="group"
@@ -257,6 +214,48 @@
             </li>
           </ul>
         </section>
+
+        <nav
+          class="mobile-actions"
+          aria-label="Acciones rápidas móviles"
+          data-quick-actions
+        >
+          <h2 class="mobile-actions__title">Acciones rápidas</h2>
+          <div class="mobile-actions__grid">
+            <button
+              class="mobile-actions__button"
+              data-action="feed"
+              data-action-button
+              type="button"
+            >
+              🍎 Dar de comer
+            </button>
+            <button
+              class="mobile-actions__button"
+              data-action="play"
+              data-action-button
+              type="button"
+            >
+              🎲 Jugar
+            </button>
+            <button
+              class="mobile-actions__button"
+              data-action="sleep"
+              data-action-button
+              type="button"
+            >
+              🌙 Dormir
+            </button>
+            <button
+              class="mobile-actions__button"
+              data-action="train"
+              data-action-button
+              type="button"
+            >
+              🏋️ Entrenar
+            </button>
+          </div>
+        </nav>
       </section>
 
       <footer class="app-footer">

--- a/scripts.js
+++ b/scripts.js
@@ -11,7 +11,9 @@ const ui = {
   attributeProgressLabel: document.querySelector("#attribute-progress-label"),
   refreshButton: document.querySelector("#refresh-status"),
   actionForm: document.querySelector("#action-form"),
-  quickActionButtons: document.querySelectorAll("[data-action-button]"),
+  quickActionButtons: document.querySelectorAll(
+    ".side-panel--actions [data-action-button], .mobile-actions [data-action-button]"
+  ),
   logList: document.querySelector("#log-list"),
   logItemTemplate: document.querySelector("#log-item-template"),
   clearLogButton: document.querySelector("#clear-log"),

--- a/styles.css
+++ b/styles.css
@@ -214,45 +214,46 @@ progress::-moz-progress-bar {
   text-align: center;
 }
 
-.mobile-quick-actions {
+.mobile-actions {
   display: none;
+  grid-column: 1 / -1;
+  gap: 1rem;
 }
 
-.mobile-quick-actions__title {
+.mobile-actions__title {
   margin: 0;
   font-size: 1.05rem;
   font-weight: 700;
-  text-align: center;
 }
 
-.mobile-quick-actions__grid {
+.mobile-actions__grid {
   display: grid;
   gap: 0.75rem;
 }
 
-.mobile-quick-actions__button {
+.mobile-actions__button {
   border: none;
   border-radius: 20px;
-  padding: 0.9rem 1rem;
+  padding: 0.95rem 1.1rem;
   background: var(--color-surface);
   box-shadow: var(--shadow-soft);
   font-weight: 600;
   color: var(--color-text);
   display: flex;
   align-items: center;
-  gap: 0.65rem;
-  justify-content: flex-start;
+  gap: 0.75rem;
+  justify-content: center;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   text-align: center;
 }
 
-.mobile-quick-actions__button:hover {
+.mobile-actions__button:hover {
   transform: translateY(-3px);
   box-shadow: 0 18px 30px rgba(139, 105, 79, 0.18);
 }
 
-.mobile-quick-actions__button:focus-visible,
+.mobile-actions__button:focus-visible,
 .sheet-toggle:focus-visible {
   outline: 3px solid rgba(244, 162, 97, 0.7);
   outline-offset: 2px;
@@ -523,6 +524,18 @@ progress::-moz-progress-bar {
   .side-panel--actions {
     display: none;
   }
+
+  .mobile-actions {
+    display: grid;
+    padding: 1rem;
+    background: rgba(255, 255, 255, 0.82);
+    border-radius: 20px;
+    box-shadow: var(--shadow-soft);
+  }
+
+  .mobile-actions__grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
 }
 
 @media (max-width: 840px) {
@@ -551,23 +564,14 @@ progress::-moz-progress-bar {
     padding-bottom: 6rem;
   }
 
-  .mobile-quick-actions {
-    display: grid;
-    gap: 1rem;
-    width: min(1100px, 92vw);
-    margin: 0 auto;
-    background: rgba(255, 255, 255, 0.92);
-    border-radius: var(--radius-large);
-    padding: 1.25rem;
-    box-shadow: var(--shadow-soft);
+  .mobile-actions {
+    padding: 0;
+    background: none;
+    box-shadow: none;
   }
 
-  .mobile-quick-actions__grid {
+  .mobile-actions__grid {
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  }
-
-  .mobile-quick-actions__button {
-    justify-content: center;
   }
 
   .mobile-sheet-toggles {
@@ -616,4 +620,9 @@ progress::-moz-progress-bar {
   .dock-form {
     grid-template-columns: 1fr;
   }
+
+  .mobile-actions__grid {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
 }
+


### PR DESCRIPTION
## Summary
- embed a mobile quick actions navigation inside the bottom dock so the shortcuts stay available when the side panel hides
- style the new mobile actions container for touch-friendly layouts and update responsive rules
- expand the quick action selector in the script to cover both side panel and mobile menus

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc8195ead4833280c30df51dc8402b